### PR TITLE
Add place to fill role-specific links to forms

### DIFF
--- a/SR2019/2019-04-14-competition-feedback.md
+++ b/SR2019/2019-04-14-competition-feedback.md
@@ -11,13 +11,22 @@ to make it happen without your efforts. In order to help us improve for the
 future, we'd really appreciate it if you could spend a few minutes providing
 some feedback on you feel the event went and what we can do to improve.
 
-In order to do that, we've prepared a couple of Google forms:
-- https://forms.gle/EgqwMHZX9FgGifUG8 for general feedback, and
-- https://forms.gle/ZPF1gCauLVQCzhT77 for role-specific feedback
+In order to do that, we've prepared some feedback forms:
 
 We'd really appreciate if you could use these to tell us about your experiences
 at the competition, whether you felt it all went well or there are things you
 think we need to improve.
+
+Please fill out https://forms.gle/EgqwMHZX9FgGifUG8 to give us general feedback.
+
+It would also be excellent if you could spend some time giving feedback on each of
+the roles you performed during the competition:
+
+<!-- personalised of roles with pre-filled links to forms, to be populated
+before sending-->
+
+Also if you'd like to fill out feedback for any other roles, please use this link:
+https://forms.gle/ZPF1gCauLVQCzhT77
 
 We'll use your feedback as the basis for discussions within the Core Team and
 wider community on what and how we can improve for the future.


### PR DESCRIPTION
I've got a script that handles generating this, but it needs more work to be a generic email generation script. I'll need to work on it a bit more before adding it to this repo.